### PR TITLE
Handle empty scopes when listing tasks

### DIFF
--- a/lib/smart_todo/tasks.ex
+++ b/lib/smart_todo/tasks.ex
@@ -18,6 +18,8 @@ defmodule SmartTodo.Tasks do
     - status: one of Task.status_values()
   Preloads prerequisites and dependents for UI.
   """
+  def list_tasks(nil, _opts), do: []
+
   def list_tasks(current_scope, opts \\ []) do
     uid = user_id!(current_scope)
 

--- a/test/smart_todo/tasks_test.exs
+++ b/test/smart_todo/tasks_test.exs
@@ -94,6 +94,10 @@ defmodule SmartTodo.TasksTest do
       ids = Tasks.list_tasks(Scope.for_user(u1)) |> Enum.map(& &1.id)
       assert ids == [t1.id]
     end
+
+    test "list_tasks/2 returns an empty list when scope is nil" do
+      assert Tasks.list_tasks(nil) == []
+    end
   end
 
   describe "dependencies and completion" do

--- a/test/smart_todo_web/live/task_live/index_test.exs
+++ b/test/smart_todo_web/live/task_live/index_test.exs
@@ -20,6 +20,13 @@ defmodule SmartTodoWeb.TaskLive.IndexTest do
     assert html =~ "What would you like me to do?"
   end
 
+  test "shows empty state when user has no tasks", %{conn: conn} do
+    conn = log_in_user(conn, user_fixture())
+    {:ok, lv, _html} = live(conn, ~p"/tasks")
+
+    assert has_element?(lv, "p", "No tasks yet — add your first one above.")
+  end
+
   test "validate shows errors and preserves multi-select selection (advanced)", %{conn: conn} do
     user = user_fixture()
     conn = log_in_user(conn, user)


### PR DESCRIPTION
## Summary
- return an empty list from `Tasks.list_tasks/2` when the scope is nil
- cover the regression with context and LiveView tests for the empty-task state

## Testing
- mix precommit *(fails: missing Hex dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4aa35c64483268971c234b34ca916