### PR TITLE
Add LLM preference settings and persistence

### DIFF
--- a/lib/smart_todo/accounts/user.ex
+++ b/lib/smart_todo/accounts/user.ex
@@ -7,6 +7,7 @@ defmodule SmartTodo.Accounts.User do
     field :password, :string, virtual: true, redact: true
     field :hashed_password, :string, redact: true
     field :authenticated_at, :utc_datetime, virtual: true
+    has_one :preference, SmartTodo.Accounts.UserPreference
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/smart_todo/accounts/user_preference.ex
+++ b/lib/smart_todo/accounts/user_preference.ex
@@ -1,0 +1,32 @@
+defmodule SmartTodo.Accounts.UserPreference do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias SmartTodo.Accounts.User
+
+  schema "user_preferences" do
+    field :prompt_preferences, :string
+    belongs_to :user, User
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(preference, attrs) do
+    preference
+    |> cast(attrs, [:prompt_preferences])
+    |> update_change(:prompt_preferences, &normalize_text/1)
+    |> validate_length(:prompt_preferences, max: 2000)
+  end
+
+  defp normalize_text(text) when is_binary(text) do
+    text
+    |> String.trim()
+    |> case do
+      "" -> nil
+      value -> value
+    end
+  end
+
+  defp normalize_text(other), do: other
+end

--- a/priv/repo/migrations/20250924040000_create_user_preferences.exs
+++ b/priv/repo/migrations/20250924040000_create_user_preferences.exs
@@ -1,0 +1,14 @@
+defmodule SmartTodo.Repo.Migrations.CreateUserPreferences do
+  use Ecto.Migration
+
+  def change do
+    create table(:user_preferences) do
+      add :prompt_preferences, :text
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:user_preferences, [:user_id])
+  end
+end


### PR DESCRIPTION
## Summary
- add a user_preferences table and Ecto schema for storing optional LLM prompt instructions per user
- surface a new Assistant Preferences form in account settings backed by the accounts context helpers
- feed the saved preferences into the Gemini system prompt and cover the flow with new tests

## Testing
- mix test *(fails: Hex install returns 503 when attempting to fetch archives in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bfe6c3648326bc02ecac398f6c84