### PR TITLE
Add record_plan command to agent workflow

### DIFF
--- a/test/smart_todo/agent/state_machine_test.exs
+++ b/test/smart_todo/agent/state_machine_test.exs
@@ -158,5 +158,23 @@ defmodule SmartTodo.Agent.StateMachineTest do
 
       assert Enum.member?(titles, "Newly created")
     end
+
+    test "record_plan stores planning notes for later reference", %{machine: machine} do
+      params = %{
+        "plan" => "Update an existing task",
+        "steps" => [
+          "record plan",
+          "select task",
+          "stage updates",
+          "complete_session"
+        ]
+      }
+
+      {:ok, machine, response} = StateMachine.handle_command(machine, :record_plan, params)
+
+      assert [%{plan: "Update an existing task", steps: steps}] = response.plan_notes
+      assert Enum.count(steps) == 4
+      assert [%{plan: "Update an existing task", steps: ^steps}] = machine.plan_notes
+    end
   end
 end


### PR DESCRIPTION
## Summary
- add a record_plan command to the agent state machine that stores planning notes alongside available commands
- expose recorded plans to the LLM session prompt, allow the new command to be resolved, and reinforce the rule that complete_session must be last
- cover the new behavior with a state machine test

## Testing
- ⚠️ `HEX_UNSAFE_HTTPS=1 mix test` *(fails: hex dependencies could not be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d60bdba3408326968d398109ad125c